### PR TITLE
Task/ctv 2273 use production version of tar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## v1.0.2
+* Use production version of TAR.
+
 ## v1.0.1
 * Default user advertising id processing now done by TAR instead.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "truex-ctv-ref-app",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1084,9 +1084,9 @@
             }
         },
         "@truex/ctv-ad-renderer": {
-            "version": "0.1.12",
-            "resolved": "https://registry.npmjs.org/@truex/ctv-ad-renderer/-/ctv-ad-renderer-0.1.12.tgz",
-            "integrity": "sha512-dOz/6ou+9K5O2Nrp1ZDteX3+XfSM6ESMm2K7vR0LRfxdopEs3bYOkYhvucrsF87g1z0RxtUVSEfirZ8X2Xw7FA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@truex/ctv-ad-renderer/-/ctv-ad-renderer-1.0.1.tgz",
+            "integrity": "sha512-rkWrzxN85dl+RGd9JS0o76dcAtO9r9meai9SGEFAMJfflByMm1Kn3J7OiWlUWbznjr+sbBzMy0dwQXMzmX76hQ==",
             "requires": {
                 "bluebird": "^3.5.1",
                 "centralize-js": "^1.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1084,9 +1084,9 @@
             }
         },
         "@truex/ctv-ad-renderer": {
-            "version": "0.1.11",
-            "resolved": "https://registry.npmjs.org/@truex/ctv-ad-renderer/-/ctv-ad-renderer-0.1.11.tgz",
-            "integrity": "sha512-JJGwqVeB6E5c23VrFMc9cln8II2nUVhTdvFzIlGh0WUQ8kxWaPtZAPje4r0jgf5w6uRzqKNgvqcCn281G8b9Hw==",
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/@truex/ctv-ad-renderer/-/ctv-ad-renderer-0.1.12.tgz",
+            "integrity": "sha512-dOz/6ou+9K5O2Nrp1ZDteX3+XfSM6ESMm2K7vR0LRfxdopEs3bYOkYhvucrsF87g1z0RxtUVSEfirZ8X2Xw7FA==",
             "requires": {
                 "bluebird": "^3.5.1",
                 "centralize-js": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "truex-ctv-ref-app",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Sample app to demonstrate how to integrate true[X]'s CTV Web ad renderer",
     "main": "index.js",
     "public": true,
@@ -36,7 +36,7 @@
         "webpack-serve": "^1.0.4"
     },
     "dependencies": {
-        "@truex/ctv-ad-renderer": "0.1.11",
+        "@truex/ctv-ad-renderer": "0.1.12",
         "core-js": "^3.6.4",
         "truex-shared": "https://github.com/socialvibe/truex-shared-js.git#v1.0.75",
         "uuid": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "webpack-serve": "^1.0.4"
     },
     "dependencies": {
-        "@truex/ctv-ad-renderer": "0.1.12",
+        "@truex/ctv-ad-renderer": "1.0.1",
         "core-js": "^3.6.4",
         "truex-shared": "https://github.com/socialvibe/truex-shared-js.git#v1.0.75",
         "uuid": "^3.4.0",


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-2273

### Description
Migrate to production version of TAR, include some production ads.

### Testing
Run end-to-end from Skyline, CTV Ref app, note that TAR tracking traffic is using production host, e.g. serve.truex.com, as opposed to qa-serve.truex.com.

### Commit Message Subject(s)
CTV-2273: v1.0.0 Production version of TAR

### Additional Context
n/a

### Related PRs
TAR HTML5: https://github.com/socialvibe/TruexAdRenderer-HTML5/pull/43

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)
