### PR TITLE
firetv build fixes

### DIFF
--- a/platforms/FireTV/RefApp/app/src/main/AndroidManifest.xml
+++ b/platforms/FireTV/RefApp/app/src/main/AndroidManifest.xml
@@ -8,6 +8,10 @@
         android:name="android.software.leanback"
         android:required="true" />
 
+    <uses-feature
+        android:name="android.hardware.touchscreen"
+        android:required="false"/>
+
     <application
         android:allowBackup="false"
         android:icon="@mipmap/app_icon"

--- a/platforms/FireTV/builder.js
+++ b/platforms/FireTV/builder.js
@@ -27,7 +27,9 @@ function build(serverUrl) {
 
     const buildApk = path.resolve(appDir, "app/build/outputs/apk/debug/app-debug.apk");
 
-    utils.spawn(getGradleScript(), ['build']);
+    const gradlew = process.platform == "win32" ? ".\\gradlew.bat" : "./gradlew";
+    utils.spawn(gradlew, ['clean', 'build'], getAppDir());
+
     const distDir = path.resolve(__dirname, '../../dist');
     utils.mkDir(distDir);
     utils.copyFile(buildApk, path.resolve(distDir, distInstaller));
@@ -36,9 +38,4 @@ function build(serverUrl) {
 
 function getAppDir() {
     return path.resolve(__dirname, "RefApp");
-}
-
-function getGradleScript() {
-    const gradlew = process.platform == "win32" ? "gradlew.bat" : "gradlew";
-    return path.resolve(getAppDir(), gradlew);
 }


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-2416
https://truextech.atlassian.net/browse/CTV-2406

### Description
Build fixes, to allow testing and installation of ref app for firetv from the command line.

### Testing
Run unit tests, run from Skyline, run from CTV ref app.
Verified that media pauses and restarts (not resumes) for choice card background video and voiceover as well as engagement ad videos and audio.

### Commit Message Subject(s)
CTV-2406, CTV-2416: unload videos and audio on suspend, hide step

### Additional Context
n/a

### Related PRs
c3: https://github.com/socialvibe/container_core/pull/313
ic: https://github.com/socialvibe/integration_core/pull/104

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)
