### PR TITLE
use TAR 1.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## v1.0.5
+* Use the latest version of TAR (1.0.11).
+
 ## v1.0.4
 * Use the latest version of TAR (1.0.9).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "truex-ctv-ref-app",
-    "version": "1.0.3",
+    "version": "1.0.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -25,19 +25,19 @@
             }
         },
         "@babel/core": {
-            "version": "7.11.1",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.1.tgz",
-            "integrity": "sha512-XqF7F6FWQdKGGWAzGELL+aCO1p+lRY5Tj5/tbT3St1G8NaH70jhhDIKknIZaDans0OQBG5wRAldROLHSt44BgQ==",
+            "version": "7.11.6",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
+            "integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.10.4",
-                "@babel/generator": "^7.11.0",
+                "@babel/generator": "^7.11.6",
                 "@babel/helper-module-transforms": "^7.11.0",
                 "@babel/helpers": "^7.10.4",
-                "@babel/parser": "^7.11.1",
+                "@babel/parser": "^7.11.5",
                 "@babel/template": "^7.10.4",
-                "@babel/traverse": "^7.11.0",
-                "@babel/types": "^7.11.0",
+                "@babel/traverse": "^7.11.5",
+                "@babel/types": "^7.11.5",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.1",
@@ -49,12 +49,12 @@
             }
         },
         "@babel/generator": {
-            "version": "7.11.0",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.0.tgz",
-            "integrity": "sha512-fEm3Uzw7Mc9Xi//qU20cBKatTfs2aOtKqmvy/Vm7RkJEGFQ4xc9myCfbXxqK//ZS8MR/ciOHw6meGASJuKmDfQ==",
+            "version": "7.11.6",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
+            "integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.11.0",
+                "@babel/types": "^7.11.5",
                 "jsesc": "^2.5.1",
                 "source-map": "^0.5.0"
             }
@@ -128,12 +128,11 @@
             }
         },
         "@babel/helper-explode-assignable-expression": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.10.4.tgz",
-            "integrity": "sha512-4K71RyRQNPRrR85sr5QY4X3VwG4wtVoXZB9+L3r1Gp38DhELyHCtovqydRi7c1Ovb17eRGiQ/FD5s8JdU0Uy5A==",
+            "version": "7.11.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.11.4.tgz",
+            "integrity": "sha512-ux9hm3zR4WV1Y3xXxXkdG/0gxF9nvI0YVmKVhvK9AfMoaQkemL3sJpXw+Xbz65azo8qJiEz2XVDUpK3KYhH3ZQ==",
             "dev": true,
             "requires": {
-                "@babel/traverse": "^7.10.4",
                 "@babel/types": "^7.10.4"
             }
         },
@@ -224,15 +223,14 @@
             }
         },
         "@babel/helper-remap-async-to-generator": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.10.4.tgz",
-            "integrity": "sha512-86Lsr6NNw3qTNl+TBcF1oRZMaVzJtbWTyTko+CQL/tvNvcGYEFKbLXDPxtW0HKk3McNOk4KzY55itGWCAGK5tg==",
+            "version": "7.11.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.11.4.tgz",
+            "integrity": "sha512-tR5vJ/vBa9wFy3m5LLv2faapJLnDFxNWff2SAYkSE4rLUdbp7CdObYFgI7wK4T/Mj4UzpjPwzR8Pzmr5m7MHGA==",
             "dev": true,
             "requires": {
                 "@babel/helper-annotate-as-pure": "^7.10.4",
                 "@babel/helper-wrap-function": "^7.10.4",
                 "@babel/template": "^7.10.4",
-                "@babel/traverse": "^7.10.4",
                 "@babel/types": "^7.10.4"
             }
         },
@@ -317,9 +315,9 @@
             }
         },
         "@babel/parser": {
-            "version": "7.11.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.3.tgz",
-            "integrity": "sha512-REo8xv7+sDxkKvoxEywIdsNFiZLybwdI7hcT5uEPyQrSMB4YQ973BfC9OOrD/81MaIjh6UxdulIQXkjmiH3PcA==",
+            "version": "7.11.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
+            "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
             "dev": true
         },
         "@babel/plugin-proposal-async-generator-functions": {
@@ -812,9 +810,9 @@
             }
         },
         "@babel/plugin-transform-runtime": {
-            "version": "7.11.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.11.0.tgz",
-            "integrity": "sha512-LFEsP+t3wkYBlis8w6/kmnd6Kb1dxTd+wGJ8MlxTGzQo//ehtqlVL4S9DNUa53+dtPSQobN2CXx4d81FqC58cw==",
+            "version": "7.11.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.11.5.tgz",
+            "integrity": "sha512-9aIoee+EhjySZ6vY5hnLjigHzunBlscx9ANKutkeWTJTx6m5Rbq6Ic01tLvO54lSusR+BxV7u4UDdCmXv5aagg==",
             "dev": true,
             "requires": {
                 "@babel/helper-module-imports": "^7.10.4",
@@ -891,9 +889,9 @@
             }
         },
         "@babel/preset-env": {
-            "version": "7.11.0",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.11.0.tgz",
-            "integrity": "sha512-2u1/k7rG/gTh02dylX2kL3S0IJNF+J6bfDSp4DI2Ma8QN6Y9x9pmAax59fsCk6QUQG0yqH47yJWA+u1I1LccAg==",
+            "version": "7.11.5",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.11.5.tgz",
+            "integrity": "sha512-kXqmW1jVcnB2cdueV+fyBM8estd5mlNfaQi6lwLgRwCby4edpavgbFhiBNjmWA3JpB/yZGSISa7Srf+TwxDQoA==",
             "dev": true,
             "requires": {
                 "@babel/compat-data": "^7.11.0",
@@ -958,7 +956,7 @@
                 "@babel/plugin-transform-unicode-escapes": "^7.10.4",
                 "@babel/plugin-transform-unicode-regex": "^7.10.4",
                 "@babel/preset-modules": "^0.1.3",
-                "@babel/types": "^7.11.0",
+                "@babel/types": "^7.11.5",
                 "browserslist": "^4.12.0",
                 "core-js-compat": "^3.6.2",
                 "invariant": "^2.2.2",
@@ -967,9 +965,9 @@
             }
         },
         "@babel/preset-modules": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.3.tgz",
-            "integrity": "sha512-Ra3JXOHBq2xd56xSF7lMKXdjBn3T772Y1Wet3yWnkDly9zHvJki029tAFzvAAK5cf4YV3yoxuP61crYRol6SVg==",
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.4.tgz",
+            "integrity": "sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.0.0",
@@ -1000,26 +998,26 @@
             }
         },
         "@babel/traverse": {
-            "version": "7.11.0",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.0.tgz",
-            "integrity": "sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==",
+            "version": "7.11.5",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
+            "integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.10.4",
-                "@babel/generator": "^7.11.0",
+                "@babel/generator": "^7.11.5",
                 "@babel/helper-function-name": "^7.10.4",
                 "@babel/helper-split-export-declaration": "^7.11.0",
-                "@babel/parser": "^7.11.0",
-                "@babel/types": "^7.11.0",
+                "@babel/parser": "^7.11.5",
+                "@babel/types": "^7.11.5",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0",
                 "lodash": "^4.17.19"
             }
         },
         "@babel/types": {
-            "version": "7.11.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
-            "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+            "version": "7.11.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
+            "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
             "dev": true,
             "requires": {
                 "@babel/helper-validator-identifier": "^7.10.4",
@@ -1084,9 +1082,9 @@
             }
         },
         "@truex/ctv-ad-renderer": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/@truex/ctv-ad-renderer/-/ctv-ad-renderer-1.0.9.tgz",
-            "integrity": "sha512-5I7id9e5msW1tH/j4nnBgYrVrz3iIobJNekhxOla6zqXVKpOcx8qayimHxQDCyHms3Au7JTmIdl2P8XcfrerDg==",
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@truex/ctv-ad-renderer/-/ctv-ad-renderer-1.0.11.tgz",
+            "integrity": "sha512-F+yXS58OaXPrhFeag5Qu6SaHw8CecKq3JIwsu2Cu2uic/6arQV4hcoWEF5ChAPBj2GZA9Vmdd56/6CAPblUl9g==",
             "requires": {
                 "bluebird": "^3.5.1",
                 "centralize-js": "^1.1.4",
@@ -1109,9 +1107,9 @@
             }
         },
         "@types/json-schema": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
-            "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
+            "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
             "dev": true
         },
         "@types/minimatch": {
@@ -1121,9 +1119,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "14.6.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.0.tgz",
-            "integrity": "sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA==",
+            "version": "14.11.3",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.3.tgz",
+            "integrity": "sha512-tPQAF6b1wak7rBO49tL2N5nNVknyHBAzJVylF5rIYkfXbFkrNpbBLFMFUjxHzuuBiR7Si7T/X4eh6IRhZxO1tQ==",
             "dev": true
         },
         "@webassemblyjs/ast": {
@@ -1404,15 +1402,15 @@
             }
         },
         "acorn": {
-            "version": "6.4.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-            "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+            "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
             "dev": true
         },
         "ajv": {
-            "version": "6.12.4",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
-            "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+            "version": "6.12.5",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+            "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
             "dev": true,
             "requires": {
                 "fast-deep-equal": "^3.1.1",
@@ -2167,15 +2165,15 @@
             }
         },
         "browserslist": {
-            "version": "4.14.0",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.0.tgz",
-            "integrity": "sha512-pUsXKAF2lVwhmtpeA3LJrZ76jXuusrNyhduuQs7CDFf9foT4Y38aQOserd2lMe5DSSrjf3fx34oHwryuvxAUgQ==",
+            "version": "4.14.5",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.5.tgz",
+            "integrity": "sha512-Z+vsCZIvCBvqLoYkBFTwEYH3v5MCQbsAjp50ERycpOjnPmolg1Gjy4+KaWWpm8QOJt9GHkhdqAl14NpCX73CWA==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30001111",
-                "electron-to-chromium": "^1.3.523",
-                "escalade": "^3.0.2",
-                "node-releases": "^1.1.60"
+                "caniuse-lite": "^1.0.30001135",
+                "electron-to-chromium": "^1.3.571",
+                "escalade": "^3.1.0",
+                "node-releases": "^1.1.61"
             }
         },
         "buffer": {
@@ -2345,9 +2343,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001116",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001116.tgz",
-            "integrity": "sha512-f2lcYnmAI5Mst9+g0nkMIznFGsArRmZ0qU+dnq8l91hymdc2J3SFbiPhOJEeDqC1vtE8nc1qNQyklzB8veJefQ==",
+            "version": "1.0.30001143",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001143.tgz",
+            "integrity": "sha512-p/PO5YbwmCpBJPxjOiKBvAlUPgF8dExhfEpnsH+ys4N/791WHrYrGg0cyHiAURl5hSbx5vIcjKmQAP6sHDYH3w==",
             "dev": true
         },
         "capture-stack-trace": {
@@ -3083,9 +3081,9 @@
                     },
                     "dependencies": {
                         "domelementtype": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
-                            "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
+                            "version": "2.0.2",
+                            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.2.tgz",
+                            "integrity": "sha512-wFwTwCVebUrMgGeAwRL/NhZtHAUyT9n9yg4IMDwf10+6iCMxSkVq9MGCVEH+QZWo1nNidy8kNvwmv4zWHDTqvA==",
                             "dev": true
                         }
                     }
@@ -3155,12 +3153,12 @@
             }
         },
         "debug": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-            "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+            "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
             "dev": true,
             "requires": {
-                "ms": "^2.1.1"
+                "ms": "2.1.2"
             }
         },
         "decamelize": {
@@ -3380,9 +3378,9 @@
             }
         },
         "dom-serializer": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.0.1.tgz",
-            "integrity": "sha512-1Aj1Qy3YLbdslkI75QEOfdp9TkQ3o8LRISAzxOibjBs/xWwr1WxZFOQphFkZuepHFGo+kB8e5FVJSS0faAJ4Rw==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.1.0.tgz",
+            "integrity": "sha512-ox7bvGXt2n+uLWtCRLybYx60IrOlWL/aCebWJk1T0d4m3y2tzf4U3ij9wBMUb6YJZpz06HCCYuyCDveE2xXmzQ==",
             "dev": true,
             "requires": {
                 "domelementtype": "^2.0.1",
@@ -3397,29 +3395,29 @@
             "dev": true
         },
         "domelementtype": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
-            "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.2.tgz",
+            "integrity": "sha512-wFwTwCVebUrMgGeAwRL/NhZtHAUyT9n9yg4IMDwf10+6iCMxSkVq9MGCVEH+QZWo1nNidy8kNvwmv4zWHDTqvA==",
             "dev": true
         },
         "domhandler": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.0.0.tgz",
-            "integrity": "sha512-eKLdI5v9m67kbXQbJSNn1zjh0SDzvzWVWtX+qEI3eMjZw8daH9k8rlj1FZY9memPwjiskQFbe7vHVVJIAqoEhw==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
+            "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
             "dev": true,
             "requires": {
                 "domelementtype": "^2.0.1"
             }
         },
         "domutils": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.2.0.tgz",
-            "integrity": "sha512-0haAxVr1PR0SqYwCH7mxMpHZUwjih9oPPedqpR/KufsnxPyZ9dyVw1R5093qnJF3WXSbjBkdzRWLw/knJV/fAg==",
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.2.tgz",
+            "integrity": "sha512-NKbgaM8ZJOecTZsIzW5gSuplsX2IWW2mIK7xVr8hTQF2v1CJWTmLZ1HOCh5sH+IzVPAGE5IucooOkvwBRAdowA==",
             "dev": true,
             "requires": {
                 "dom-serializer": "^1.0.1",
                 "domelementtype": "^2.0.1",
-                "domhandler": "^3.0.0"
+                "domhandler": "^3.3.0"
             }
         },
         "dot-case": {
@@ -3502,9 +3500,9 @@
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.3.539",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.539.tgz",
-            "integrity": "sha512-rM0LWDIstdqfaRUADZetNrL6+zd/0NBmavbMEhBXgc2u/CC1d1GaDyN5hho29fFvBiOVFwrSWZkzmNcZnCEDog==",
+            "version": "1.3.576",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.576.tgz",
+            "integrity": "sha512-uSEI0XZ//5ic+0NdOqlxp0liCD44ck20OAGyLMSymIWTEAtHKVJi6JM18acOnRgUgX7Q65QqnI+sNncNvIy8ew==",
             "dev": true
         },
         "elliptic": {
@@ -3629,20 +3627,21 @@
             }
         },
         "es-abstract": {
-            "version": "1.17.6",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-            "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+            "version": "1.18.0-next.1",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+            "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
             "dev": true,
             "requires": {
                 "es-to-primitive": "^1.2.1",
                 "function-bind": "^1.1.1",
                 "has": "^1.0.3",
                 "has-symbols": "^1.0.1",
-                "is-callable": "^1.2.0",
-                "is-regex": "^1.1.0",
-                "object-inspect": "^1.7.0",
+                "is-callable": "^1.2.2",
+                "is-negative-zero": "^2.0.0",
+                "is-regex": "^1.1.1",
+                "object-inspect": "^1.8.0",
                 "object-keys": "^1.1.1",
-                "object.assign": "^4.1.0",
+                "object.assign": "^4.1.1",
                 "string.prototype.trimend": "^1.0.1",
                 "string.prototype.trimstart": "^1.0.1"
             }
@@ -3691,9 +3690,9 @@
             }
         },
         "escalade": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.2.tgz",
-            "integrity": "sha512-gPYAU37hYCUhW5euPeR+Y74F7BL+IBsV93j5cvGriSaD1aG6MGsqsV1yamRdrWrb2j3aiZvb0X+UBOWpx3JWtQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.0.tgz",
+            "integrity": "sha512-mAk+hPSO8fLDkhV7V0dXazH5pDc6MrjBTPyD3VeKzxnVFjH1MIxbCdqGZB9O8+EwWakZs3ZCbDS4IpRt79V1ig==",
             "dev": true
         },
         "escape-html": {
@@ -3725,12 +3724,20 @@
             "dev": true
         },
         "esrecurse": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-            "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
             "dev": true,
             "requires": {
-                "estraverse": "^4.1.0"
+                "estraverse": "^5.2.0"
+            },
+            "dependencies": {
+                "estraverse": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+                    "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+                    "dev": true
+                }
             }
         },
         "estraverse": {
@@ -3752,9 +3759,9 @@
             "dev": true
         },
         "eventemitter3": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-            "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==",
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
             "dev": true
         },
         "events": {
@@ -3948,9 +3955,9 @@
             },
             "dependencies": {
                 "type": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
-                    "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==",
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
+                    "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA==",
                     "dev": true
                 }
             }
@@ -4081,13 +4088,13 @@
             "dev": true
         },
         "file-loader": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.0.0.tgz",
-            "integrity": "sha512-/aMOAYEFXDdjG0wytpTL5YQLfZnnTmLNjn+AIrJ/6HVnTfDqLsVKUUwkDf4I4kgex36BvjuXEn/TX9B/1ESyqQ==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.1.0.tgz",
+            "integrity": "sha512-26qPdHyTsArQ6gU4P1HJbAbnFTyT2r0pG7czh1GFAd9TZbj0n94wWbupgixZH/ET/meqi2/5+F7DhW4OAXD+Lg==",
             "dev": true,
             "requires": {
                 "loader-utils": "^2.0.0",
-                "schema-utils": "^2.6.5"
+                "schema-utils": "^2.7.1"
             },
             "dependencies": {
                 "loader-utils": {
@@ -4796,15 +4803,15 @@
             "dev": true
         },
         "html-loader": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/html-loader/-/html-loader-1.2.1.tgz",
-            "integrity": "sha512-oE92tLmSnWIjM0190s8+MiwNAKValkddHSVphSR37MrwcP3iy/rbbw4N7hSLG+m3OiuVRwVHJYFcIYfN2xqUHQ==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/html-loader/-/html-loader-1.3.1.tgz",
+            "integrity": "sha512-zL+z9mIhcXEXuHqzriTwZR4ZslZHi5IFNhjyJHyhJlhEgR8VtLTPbqeR5TdbNtHtb88zbVmlNB8ia2vr/GTrbA==",
             "dev": true,
             "requires": {
                 "html-minifier-terser": "^5.1.1",
                 "htmlparser2": "^4.1.0",
                 "loader-utils": "^2.0.0",
-                "schema-utils": "^2.7.0"
+                "schema-utils": "^2.7.1"
             },
             "dependencies": {
                 "loader-utils": {
@@ -5245,9 +5252,9 @@
             "dev": true
         },
         "is-callable": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-            "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+            "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
             "dev": true
         },
         "is-ci": {
@@ -5372,6 +5379,12 @@
                     }
                 }
             }
+        },
+        "is-negative-zero": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
+            "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=",
+            "dev": true
         },
         "is-npm": {
             "version": "1.0.0",
@@ -5840,9 +5853,9 @@
             }
         },
         "loglevel": {
-            "version": "1.6.8",
-            "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.8.tgz",
-            "integrity": "sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.0.tgz",
+            "integrity": "sha512-i2sY04nal5jDcagM3FMfG++T69GEEM8CYuOfeOIvmXzOIcwE9a/CJPR0MFM97pYMj/u10lzz7/zd7+qwhrBTqQ==",
             "dev": true
         },
         "loglevelnext": {
@@ -6310,9 +6323,9 @@
             }
         },
         "node-forge": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-            "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+            "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
             "dev": true
         },
         "node-gyp": {
@@ -6409,9 +6422,9 @@
             }
         },
         "node-releases": {
-            "version": "1.1.60",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.60.tgz",
-            "integrity": "sha512-gsO4vjEdQaTusZAEebUWp2a5d7dF5DYoIpDG7WySnk7BuZDW+GPpHXoXXuYawRBr/9t5q54tirPz79kFIWg4dA==",
+            "version": "1.1.61",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.61.tgz",
+            "integrity": "sha512-DD5vebQLg8jLCOzwupn954fbIiZht05DAZs0k2u8NStSe6h9XdsuIQL8hSRKYiU8WUQRznmSDrKGbv3ObOmC7g==",
             "dev": true
         },
         "node-sass": {
@@ -6579,13 +6592,13 @@
             "dev": true
         },
         "object-is": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
-            "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.3.tgz",
+            "integrity": "sha512-teyqLvFWzLkq5B9ki8FVWA902UER2qkxmdA4nLf+wjOLAWgxzCWZNCxpDq9MvE8MmhWNr+I8w3BN49Vx36Y6Xg==",
             "dev": true,
             "requires": {
                 "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.5"
+                "es-abstract": "^1.18.0-next.1"
             }
         },
         "object-keys": {
@@ -6604,15 +6617,15 @@
             }
         },
         "object.assign": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-            "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
+            "integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.2",
-                "function-bind": "^1.1.1",
-                "has-symbols": "^1.0.0",
-                "object-keys": "^1.0.11"
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.18.0-next.0",
+                "has-symbols": "^1.0.1",
+                "object-keys": "^1.1.1"
             }
         },
         "object.getownpropertydescriptors": {
@@ -6623,6 +6636,27 @@
             "requires": {
                 "define-properties": "^1.1.3",
                 "es-abstract": "^1.17.0-next.1"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                }
             }
         },
         "object.pick": {
@@ -7028,9 +7062,9 @@
             "dev": true
         },
         "postcss": {
-            "version": "7.0.32",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
-            "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
+            "version": "7.0.35",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
+            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
             "dev": true,
             "requires": {
                 "chalk": "^2.4.2",
@@ -7097,14 +7131,15 @@
             }
         },
         "postcss-selector-parser": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
-            "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz",
+            "integrity": "sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==",
             "dev": true,
             "requires": {
                 "cssesc": "^3.0.0",
                 "indexes-of": "^1.0.1",
-                "uniq": "^1.0.1"
+                "uniq": "^1.0.1",
+                "util-deprecate": "^1.0.2"
             }
         },
         "postcss-value-parser": {
@@ -7148,9 +7183,9 @@
             "dev": true
         },
         "properties-reader": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/properties-reader/-/properties-reader-2.0.0.tgz",
-            "integrity": "sha512-wEvznelF2vGq52VA51j8ZNoUZOeCJQd2kh5CGHLOhdLKKN176ZAdYv+WH6s6tj7IOBLFRkWhMPQjq8uzyFe37Q==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/properties-reader/-/properties-reader-2.1.1.tgz",
+            "integrity": "sha512-1t9JG6aMQn/I6ZzwbusXJB4pvHLbi43cQVZj56CuBq7tUmLe1S/HtSN5iqw4qg26UxOQLj0IEfikD5Zcrc3XvA==",
             "dev": true,
             "requires": {
                 "mkdirp": "~0.5.1"
@@ -7458,12 +7493,33 @@
             "requires": {
                 "define-properties": "^1.1.3",
                 "es-abstract": "^1.17.0-next.1"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                }
             }
         },
         "regexpu-core": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.0.tgz",
-            "integrity": "sha512-TQ4KXRnIn6tz6tjnrXEkD/sshygKH/j5KzK86X8MkeHyZ8qst/LZ89j3X4/8HEIfHANTFIP/AbXakeRhWIl5YQ==",
+            "version": "4.7.1",
+            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.1.tgz",
+            "integrity": "sha512-ywH2VUraA44DZQuRKzARmw6S66mr48pQVva4LBeRhcOltJ6hExvWly5ZjFLYo67xbIxb6W1q4bAGtgfEl20zfQ==",
             "dev": true,
             "requires": {
                 "regenerate": "^1.4.0",
@@ -7558,9 +7614,9 @@
                     },
                     "dependencies": {
                         "domelementtype": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
-                            "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
+                            "version": "2.0.2",
+                            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.2.tgz",
+                            "integrity": "sha512-wFwTwCVebUrMgGeAwRL/NhZtHAUyT9n9yg4IMDwf10+6iCMxSkVq9MGCVEH+QZWo1nNidy8kNvwmv4zWHDTqvA==",
                             "dev": true
                         },
                         "entities": {
@@ -7875,14 +7931,14 @@
             }
         },
         "schema-utils": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
-            "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
+            "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
             "dev": true,
             "requires": {
-                "@types/json-schema": "^7.0.4",
-                "ajv": "^6.12.2",
-                "ajv-keywords": "^3.4.1"
+                "@types/json-schema": "^7.0.5",
+                "ajv": "^6.12.4",
+                "ajv-keywords": "^3.5.2"
             }
         },
         "scss-tokenizer": {
@@ -7913,12 +7969,12 @@
             "dev": true
         },
         "selfsigned": {
-            "version": "1.10.7",
-            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-            "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+            "version": "1.10.8",
+            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+            "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
             "dev": true,
             "requires": {
-                "node-forge": "0.9.0"
+                "node-forge": "^0.10.0"
             }
         },
         "semver": {
@@ -8389,9 +8445,9 @@
             }
         },
         "spdx-license-ids": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-            "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.6.tgz",
+            "integrity": "sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw==",
             "dev": true
         },
         "spdy": {
@@ -8634,6 +8690,27 @@
             "requires": {
                 "define-properties": "^1.1.3",
                 "es-abstract": "^1.17.5"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                }
             }
         },
         "string.prototype.trimstart": {
@@ -8644,6 +8721,27 @@
             "requires": {
                 "define-properties": "^1.1.3",
                 "es-abstract": "^1.17.5"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                }
             }
         },
         "string_decoder": {
@@ -8703,13 +8801,13 @@
             "dev": true
         },
         "style-loader": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.2.1.tgz",
-            "integrity": "sha512-ByHSTQvHLkWE9Ir5+lGbVOXhxX10fbprhLvdg96wedFZb4NDekDPxVKv5Fwmio+QcMlkkNfuK+5W1peQ5CUhZg==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.3.0.tgz",
+            "integrity": "sha512-V7TCORko8rs9rIqkSrlMfkqA63DfoGBBJmK1kKGCcSi+BWb4cqz0SRsnp4l6rU5iwOEd0/2ePv68SV22VXon4Q==",
             "dev": true,
             "requires": {
                 "loader-utils": "^2.0.0",
-                "schema-utils": "^2.6.6"
+                "schema-utils": "^2.7.0"
             },
             "dependencies": {
                 "loader-utils": {
@@ -8933,9 +9031,9 @@
             "dev": true
         },
         "time-fix-plugin": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/time-fix-plugin/-/time-fix-plugin-2.0.6.tgz",
-            "integrity": "sha512-2cjjg3672ppNm/uKhHAoCFp1ItEAiH+xJOjO9WGIF8hXuxPAJ2adfYgFiyooVbsOb948c+WrRh+edxFUMxYHoQ==",
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/time-fix-plugin/-/time-fix-plugin-2.0.7.tgz",
+            "integrity": "sha512-uVFet1LQToeUX0rTcSiYVYVoGuBpc8gP/2jnlUzuHMHe+gux6XLsNzxLUweabMwiUj5ejhoIMsUI55nVSEa/Vw==",
             "dev": true
         },
         "timed-out": {
@@ -9286,9 +9384,9 @@
             "dev": true
         },
         "uri-js": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-            "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+            "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
             "dev": true,
             "requires": {
                 "punycode": "^2.1.0"
@@ -9605,9 +9703,9 @@
             }
         },
         "webpack": {
-            "version": "4.44.1",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.1.tgz",
-            "integrity": "sha512-4UOGAohv/VGUNQJstzEywwNxqX417FnjZgZJpJQegddzPmTvph37eBIRbRTfdySXzVtJXLJfbMN3mMYhM6GdmQ==",
+            "version": "4.44.2",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.2.tgz",
+            "integrity": "sha512-6KJVGlCxYdISyurpQ0IPTklv+DULv05rs2hseIXer6D7KrUicRDLFb4IUM1S6LUAKypPM/nSiVSuv8jHu1m3/Q==",
             "dev": true,
             "requires": {
                 "@webassemblyjs/ast": "1.9.0",
@@ -10259,9 +10357,9 @@
             "dev": true
         },
         "whatwg-fetch": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.0.tgz",
-            "integrity": "sha512-rsum2ulz2iuZH08mJkT0Yi6JnKhwdw4oeyMjokgxd+mmqYSd9cPpOQf01TIWgjxG/U4+QR+AwKq6lSbXVxkyoQ=="
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz",
+            "integrity": "sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ=="
         },
         "which": {
             "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "truex-ctv-ref-app",
-    "version": "1.0.3",
+    "version": "1.0.5",
     "description": "Sample app to demonstrate how to integrate true[X]'s CTV Web ad renderer",
     "main": "index.js",
     "public": true,
@@ -36,7 +36,7 @@
         "webpack-serve": "^1.0.4"
     },
     "dependencies": {
-        "@truex/ctv-ad-renderer": "1.0.9",
+        "@truex/ctv-ad-renderer": "1.0.11",
         "core-js": "^3.6.4",
         "truex-shared": "https://github.com/socialvibe/truex-shared-js.git#v1.0.75",
         "uuid": "^3.4.0",


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-2440

### Description
* Add missing creative_id and campaign_id fields to track event calls.
* Actual trackEvent() implementation is on the ChoiceCard
* Skyline/TAR now uses trackingObserver instad of trackingListener
* Other TAR clients updated to use TAR 1.0.11

### Testing
Unit tests
Tested via Skyline, ref apps, ran firetv webview standalone.

### Commit Message Subject(s)
CTV-2440: creative_id and campaign_id missing from choice card events

### Additional Context
n/a

### Related PRs
ic: https://github.com/socialvibe/integration_core/pull/108
TAR HTML: https://github.com/socialvibe/TruexAdRenderer-HTML5/pull/53
Skyline: https://github.com/socialvibe/Skyline/pull/81

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)
