### PR TITLE
use latest TAR, truex-shared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## v1.0.9
+* Use persistent fallback advertising id.
+
 ## v1.0.8
 * PS4 video playback fixes.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "truex-ctv-ref-app",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1082,27 +1082,18 @@
             }
         },
         "@truex/ctv-ad-renderer": {
-            "version": "1.0.21",
-            "resolved": "https://registry.npmjs.org/@truex/ctv-ad-renderer/-/ctv-ad-renderer-1.0.21.tgz",
-            "integrity": "sha512-NFHm4nutCaKVKqGj16XomPXD2Pt8cbp7jJvVRaTwywjMLks3JXCgAopmiSECLTmQeWYAWvbLD3Z1K/YEw2OiEQ==",
+            "version": "1.0.24",
+            "resolved": "https://registry.npmjs.org/@truex/ctv-ad-renderer/-/ctv-ad-renderer-1.0.24.tgz",
+            "integrity": "sha512-HQqA+0sRb8qKHcjn0WsGKTUzijQfxMDZmf4033PgauFz3fUfXGiUaLrXzTl9Gqq2oNLwHax2Q5Nt6zHzc5ALsw==",
             "requires": {
                 "bluebird": "^3.5.1",
                 "centralize-js": "^1.1.4",
                 "core-js": "^3.6.4",
                 "lodash.merge": "^4.6.2",
                 "raven-js": "^3.25.2",
-                "truex-shared": "git+https://github.com/socialvibe/truex-shared-js.git#v1.0.75",
+                "truex-shared": "git+https://github.com/socialvibe/truex-shared-js.git#v1.0.79",
                 "uuid": "^3.4.0",
                 "whatwg-fetch": "^3.0.0"
-            },
-            "dependencies": {
-                "truex-shared": {
-                    "version": "git+https://github.com/socialvibe/truex-shared-js.git#221981a8cee7cde2a4af457476d812922232a7f5",
-                    "from": "git+https://github.com/socialvibe/truex-shared-js.git#v1.0.75",
-                    "requires": {
-                        "uuid": "^3.4.0"
-                    }
-                }
             }
         },
         "@types/glob": {
@@ -9152,8 +9143,8 @@
             }
         },
         "truex-shared": {
-            "version": "git+https://github.com/socialvibe/truex-shared-js.git#7a83897a3eb6b673bf7c636006301df755fe6cf2",
-            "from": "git+https://github.com/socialvibe/truex-shared-js.git#v1.0.77",
+            "version": "git+https://github.com/socialvibe/truex-shared-js.git#3c65d980c635511403326747bf739c4cb540a678",
+            "from": "git+https://github.com/socialvibe/truex-shared-js.git#v1.0.79",
             "requires": {
                 "uuid": "^3.4.0"
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "truex-ctv-ref-app",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "description": "Sample app to demonstrate how to integrate true[X]'s CTV Web ad renderer",
     "main": "index.js",
     "public": true,
@@ -36,9 +36,9 @@
         "webpack-serve": "^1.0.4"
     },
     "dependencies": {
-        "@truex/ctv-ad-renderer": "1.0.21",
+        "@truex/ctv-ad-renderer": "1.0.24",
         "core-js": "^3.6.4",
-        "truex-shared": "https://github.com/socialvibe/truex-shared-js.git#v1.0.77",
+        "truex-shared": "https://github.com/socialvibe/truex-shared-js.git#v1.0.79",
         "uuid": "^3.4.0",
         "whatwg-fetch": "^3.0.0"
     }


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-2153

### Description
Persist the fallback advertising id across TAR instances, via local storage.

### Testing
Run from Ref app, verify TAR version.

### Commit Message Subject(s)
CTV-2153: Use persistent fallback advertising id.

### Additional Context
n/a

### Related PRs
n/a

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)
 