### PR TITLE
Task/ctv 2970 use shared deploy code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- "11.10.1"
+  - "14.16.1"
 sudo: required
 branches:
   only:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## v1.3.0
+* Use latest TAR, truex-shared for S3 deploy fixes
+
 ## v1.2.3
 * Use latest TAR for polyfill fixes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1093,16 +1093,16 @@
             }
         },
         "@truex/ctv-ad-renderer": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/@truex/ctv-ad-renderer/-/ctv-ad-renderer-1.2.7.tgz",
-            "integrity": "sha512-xhlx9rCxwS+78GXbNOYyosH4q2e4SCuNh/ALGZu8k07Ijr+WzQT4kscBjtWxYsCnfSDX3ZJp1sSONo8TzSBuvQ==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@truex/ctv-ad-renderer/-/ctv-ad-renderer-1.3.3.tgz",
+            "integrity": "sha512-muvf6O2Njd5k0NcMeXaJxfUv7PgIiACHwjHhpdQ7wgan80ym2BT/oSW3trwAebT3pma0cHaJoz4stjgNE/NeZA==",
             "requires": {
                 "bluebird": "^3.5.1",
                 "centralize-js": "^1.1.4",
                 "core-js": "^3.6.4",
                 "lodash.merge": "^4.6.2",
                 "raven-js": "^3.25.2",
-                "truex-shared": "git+https://github.com/socialvibe/truex-shared-js.git#v1.2.7",
+                "truex-shared": "git+https://github.com/socialvibe/truex-shared-js.git#v1.3.6",
                 "uuid": "^3.4.0",
                 "whatwg-fetch": "^3.0.0"
             }
@@ -1724,7 +1724,6 @@
             "version": "2.887.0",
             "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.887.0.tgz",
             "integrity": "sha512-jFRVrdyvBEYmSSrriA92dXDn1VgCXnz6Rax6wRGQDhyCWH+9NzZ7ZvIag2Yy2SLpvoRU7IaiEmiBLbNe/BksgA==",
-            "dev": true,
             "requires": {
                 "buffer": "4.9.2",
                 "events": "1.1.1",
@@ -1740,20 +1739,17 @@
                 "events": {
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-                    "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
-                    "dev": true
+                    "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
                 },
                 "punycode": {
                     "version": "1.3.2",
                     "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-                    "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-                    "dev": true
+                    "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
                 },
                 "url": {
                     "version": "0.10.3",
                     "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
                     "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
-                    "dev": true,
                     "requires": {
                         "punycode": "1.3.2",
                         "querystring": "0.2.0"
@@ -1762,8 +1758,7 @@
                 "uuid": {
                     "version": "3.3.2",
                     "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-                    "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-                    "dev": true
+                    "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
                 }
             }
         },
@@ -1865,8 +1860,7 @@
         "base64-js": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-            "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-            "dev": true
+            "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
         },
         "bcrypt-pbkdf": {
             "version": "1.0.2",
@@ -2130,7 +2124,6 @@
             "version": "4.9.2",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
             "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-            "dev": true,
             "requires": {
                 "base64-js": "^1.0.2",
                 "ieee754": "^1.1.4",
@@ -3042,6 +3035,11 @@
                 "array-find-index": "^1.0.1"
             }
         },
+        "cycle": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+            "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
+        },
         "cyclist": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
@@ -3336,6 +3334,39 @@
             "requires": {
                 "jsbn": "~0.1.0",
                 "safer-buffer": "^2.1.0"
+            }
+        },
+        "edgecast-purge": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/edgecast-purge/-/edgecast-purge-0.1.1.tgz",
+            "integrity": "sha512-V2C/VGddV9DrYd6gIiSe9qAa2TnDyqMm8CZ91pdqUS6bhfUmwbUNoyJGibtgdW/ty5F3iiVKF1fowk1kBXlypg==",
+            "requires": {
+                "winston": "^2.4.0"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+                    "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+                },
+                "colors": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+                    "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+                },
+                "winston": {
+                    "version": "2.4.5",
+                    "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.5.tgz",
+                    "integrity": "sha512-TWoamHt5yYvsMarGlGEQE59SbJHqGsZV8/lwC+iCcGeAe0vUaOh+Lv6SYM17ouzC/a/LB1/hz/7sxFBtlu1l4A==",
+                    "requires": {
+                        "async": "~1.0.0",
+                        "colors": "1.0.x",
+                        "cycle": "1.0.x",
+                        "eyes": "0.1.x",
+                        "isstream": "0.1.x",
+                        "stack-trace": "0.0.x"
+                    }
+                }
             }
         },
         "ee-first": {
@@ -3792,6 +3823,11 @@
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
             "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
             "dev": true
+        },
+        "eyes": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+            "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
         },
         "fast-deep-equal": {
             "version": "3.1.3",
@@ -4644,8 +4680,7 @@
         "ieee754": {
             "version": "1.1.13",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-            "dev": true
+            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
         },
         "iferr": {
             "version": "0.1.5",
@@ -5045,8 +5080,7 @@
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-            "dev": true
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "isexe": {
             "version": "2.0.0",
@@ -5063,14 +5097,12 @@
         "isstream": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-            "dev": true
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
         },
         "jmespath": {
             "version": "0.15.0",
             "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-            "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
-            "dev": true
+            "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
         },
         "js-base64": {
             "version": "2.6.4",
@@ -5395,11 +5427,6 @@
                 "ms": "^2.1.1",
                 "triple-beam": "^1.3.0"
             }
-        },
-        "logger": {
-            "version": "gist:b7faf81423cf2c32e65e9e56317b81a6#728817307cc84f672397f54517d54353d9a996cc",
-            "from": "gist:b7faf81423cf2c32e65e9e56317b81a6",
-            "dev": true
         },
         "loglevelnext": {
             "version": "1.0.5",
@@ -6641,11 +6668,6 @@
                 }
             }
         },
-        "promisify": {
-            "version": "gist:a13188cf82c74ea5ced97452799668f0#3cfe8a6921b34379f1c98c3ebf60638aaa58c9d9",
-            "from": "gist:a13188cf82c74ea5ced97452799668f0",
-            "dev": true
-        },
         "properties-reader": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/properties-reader/-/properties-reader-2.1.1.tgz",
@@ -6743,8 +6765,7 @@
         "querystring": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-            "dev": true
+            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
         },
         "querystring-es3": {
             "version": "0.2.1",
@@ -7324,8 +7345,7 @@
         "sax": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-            "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
-            "dev": true
+            "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
         },
         "schema-utils": {
             "version": "2.7.1",
@@ -7734,8 +7754,7 @@
         "stack-trace": {
             "version": "0.0.10",
             "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
-            "dev": true
+            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
         },
         "static-extend": {
             "version": "0.1.2",
@@ -8368,10 +8387,13 @@
             }
         },
         "truex-shared": {
-            "version": "git+https://github.com/socialvibe/truex-shared-js.git#af6a505f573dcb17e736e36e3478bd23f0d5ac12",
-            "from": "git+https://github.com/socialvibe/truex-shared-js.git#v1.2.7",
+            "version": "git+https://github.com/socialvibe/truex-shared-js.git#73e858112ac3a34014e88e2b8975174fa0c9db73",
+            "from": "git+https://github.com/socialvibe/truex-shared-js.git#v1.3.6",
             "requires": {
-                "uuid": "^3.4.0"
+                "aws-sdk": "^2.260.1",
+                "edgecast-purge": "^0.1.1",
+                "uuid": "^3.4.0",
+                "whatwg-fetch": "^3.0.0"
             }
         },
         "tslib": {
@@ -9557,7 +9579,6 @@
             "version": "0.4.19",
             "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
             "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-            "dev": true,
             "requires": {
                 "sax": ">=0.6.0",
                 "xmlbuilder": "~9.0.1"
@@ -9566,8 +9587,7 @@
         "xmlbuilder": {
             "version": "9.0.7",
             "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
-            "dev": true
+            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
         },
         "xtend": {
             "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -35,23 +35,20 @@
         "svg-inline-loader": "^0.8.2",
         "html-webpack-plugin": "^3.2.0",
         "invalidate-cloudfront-edge-cache": "^1.1.0",
-        "logger": "gist:b7faf81423cf2c32e65e9e56317b81a6",
         "node-sass": "^4.14.1",
         "promise-to-upload-dist": "^0.0.7",
-        "promisify": "gist:a13188cf82c74ea5ced97452799668f0",
         "properties-reader": "^2.0.0",
         "run-func": "^1.0.5",
-        "s3-upload": "gist:eb216ab0f687c7d9f3691f2efa7715bb",
         "sass-loader": "^8.0.2",
         "webpack": "^4.12.0",
         "webpack-cli": "^3.0.8",
         "webpack-serve": "^1.0.4"
     },
     "dependencies": {
-        "@truex/ctv-ad-renderer": "1.2.7",
+        "@truex/ctv-ad-renderer": "1.3.3",
         "adm-zip": "^0.5.1",
         "core-js": "^3.6.4",
-        "truex-shared": "https://github.com/socialvibe/truex-shared-js.git#v1.2.7",
+        "truex-shared": "https://github.com/socialvibe/truex-shared-js.git#v1.3.6",
         "uuid": "^3.4.0",
         "whatwg-fetch": "^3.0.0"
     }

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -1,15 +1,12 @@
 #!/usr/bin/env node
 
-require('promisify').polyfill();
+require('truex-shared/src/deploy/promisify').polyfill();
 
-const logger = require('logger');
-const s3 = require('s3-upload');
-const uploadDist = require('promise-to-upload-dist');
+const s3 = require('truex-shared/src/deploy/s3-upload');
+const uploadDist = require('truex-shared/src/deploy/upload-dist');
 const awsCloudFrontInvalidate = require("invalidate-cloudfront-edge-cache");
 
 const deploy = () => {
-    const log = logger.create('deploy');
-
     const bucket = "ctv.truex.com";
     const branch = process.env.TRAVIS_BRANCH;
     const prefix = 'web/ref-app/' + branch;
@@ -20,7 +17,7 @@ const deploy = () => {
 
     if (isPR) {
         // We only want to deploy on the final merges.
-        log(`PR deploy skipped for ${bucket}/${prefix}`);
+        console.log(`PR deploy skipped for ${bucket}/${prefix}`);
         process.exit(0);
     }
 
@@ -30,12 +27,12 @@ const deploy = () => {
             return uploadDist(bucket, prefix);
         })
         .then(() => {
-            log("invalidating cloudfront cache");
+            console.log("invalidating cloudfront cache");
             const pathsToInvalidate = [`/${prefix}/index.html`];
             return awsCloudFrontInvalidate(cloudFrontDistId, pathsToInvalidate);
         })
         .then(() => {
-            log("deploy complete");
+            console.log("deploy complete");
         })
         .catch((err) => {
             console.error(`deploy error: ${err}`);


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-2970

### Description
Ensure all existing travis deploy JS scripts are used from a common place in truex-shared/src/deploy, as opposed to the previous method of duplicate copies across repos, or references to (unmaintainable) gist dependencies.

Also updating TAR, truex-shared references across the board to minimize multiple version of that module for a given project.

### Testing
Review travis deploy log when merging this PR.
Run ref app from the merged develop branch to exercise that the deploy still works.

### Commit Message Subject
CTV-2970: Use common deploy scripts from truex-shared

### Additional Context

### Related PRs
TAR: https://github.com/socialvibe/TruexAdRenderer-HTML5/pull/84
Skyline: https://github.com/socialvibe/Skyline/pull/190

### Checks
- [ ] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)
